### PR TITLE
Update the build SDK to version 3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "nuget"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "gh-actions"

--- a/.github/github-labels.yml
+++ b/.github/github-labels.yml
@@ -36,6 +36,14 @@
   color: '008672'
   description: "Changes related to unit tests"
 
+# Additional Labels Used by Dependabot
+- name: gh-actions
+  color: '1d0128'
+  description: "Version updates for GitHub actions"
+- name: nuget
+  color: '1d0128'
+  description: "Version updates for NuGet packages"
+
 # Additional Labels for Release Drafter Version Resolution
 - name: bump-major-version
   color: 'cf996b'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      dotnet-version: 8.0.x
+    strategy:
+      matrix:
+        configuration: ['Debug', 'Release']
+
+    steps:
+    - name: Check out the project
+      uses: actions/checkout@v4
+    - name: Set up .NET ${{env.dotnet-version}}
+      uses: actions/setup-dotnet@v4
+      id: setup
+      with:
+        dotnet-version: ${{env.dotnet-version}}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
+      run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
+    - name: Run build script (${{matrix.configuration}})
+      run: pwsh ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
+    - name: "Artifact: MSBuild Logs"
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: MSBuild Logs (${{matrix.configuration}})
+        path: msbuild.*.binlog
+    - name: "Artifact: NuGet Packages"
+      uses: actions/upload-artifact@v3
+      with:
+        name: NuGet Packages (${{matrix.configuration}})
+        path: "output/package/${{matrix.configuration}}/*.*nupkg"
+    - name: Publish (NuGet - GitHub Packages)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+    - name: Publish (NuGet - nuget.org)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5.15.0
+      - uses: release-drafter/release-drafter@v5.25.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Labeler
         if: success()
-        uses: crazy-max/ghaction-github-labeler@v3
+        uses: crazy-max/ghaction-github-labeler@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/github-labels.yml

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
 
   <!-- Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageVersion Include="MetaBrainz.Common" Version="1.0.0" />
     <PackageVersion Include="MetaBrainz.Common.Json" Version="5.1.0" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021 Tim Van Holder
+Copyright (c) 2020, 2023 Tim Van Holder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MetaBrainz.CritiqueBrainz.sln
+++ b/MetaBrainz.CritiqueBrainz.sln
@@ -8,10 +8,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Fi
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		appveyor.yml = appveyor.yml
 		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
-		global.json = global.json
 		LICENSE.md = LICENSE.md
 		package-icon.png = package-icon.png
 		README.md = README.md
@@ -26,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{5035CE
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{8BC2787B-BAA2-4CA9-8BDC-4866DD88018C}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\release-drafter.yml = .github\workflows\release-drafter.yml
 		.github\workflows\update-labels.yml = .github\workflows\update-labels.yml
 	EndProjectSection

--- a/MetaBrainz.CritiqueBrainz.sln.DotSettings
+++ b/MetaBrainz.CritiqueBrainz.sln.DotSettings
@@ -60,4 +60,5 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Brainz/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Brainz/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=critiquebrainz/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/MetaBrainz.CritiqueBrainz/MetaBrainz.CritiqueBrainz.csproj
+++ b/MetaBrainz.CritiqueBrainz/MetaBrainz.CritiqueBrainz.csproj
@@ -1,19 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MetaBrainz.Build.Sdk">
+<Project>
+
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.0" />
 
   <PropertyGroup>
+    <Authors>Zastai</Authors>
     <Title>CritiqueBrainz Web Service Client Library</Title>
     <Description>This package provides classes for accessing the CritiqueBrainz API (v1).</Description>
-    <PackageCopyrightYears>2020</PackageCopyrightYears>
+    <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
+    <PackageCopyrightYears>2020, 2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.CritiqueBrainz</PackageRepositoryName>
     <PackageTags>CritiqueBrainz music reviews</PackageTags>
     <Version>1.0.0-pre</Version>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AssemblyIsComVisible>false</AssemblyIsComVisible>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" IncludeAssets="compile" PrivateAssets="all" />
     <PackageReference Include="MetaBrainz.Common.Json" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MetaBrainz.CritiqueBrainz [![Build Status](https://img.shields.io/appveyor/build/zastai/metabrainz-critiquebrainz)](https://ci.appveyor.com/project/Zastai/metabrainz-critiquebrainz) [![NuGet Version](https://img.shields.io/nuget/v/MetaBrainz.CritiqueBrainz)](https://www.nuget.org/packages/MetaBrainz.CritiqueBrainz)
+# MetaBrainz.CritiqueBrainz [![Build Status][CI-S]][CI-L] [![NuGet Version][NuGet-S]][NuGet-L]
 
 This is a library providing access to the
 [CritiqueBrainz API v1][api-reference].
@@ -7,6 +7,20 @@ This is a library providing access to the
 music reviews; it is based on data from [MusicBrainz][mb-home], an open
 music encyclopedia.
 
+This also contains OAuth2 functionality.
+
+## Release Notes
+
+These are available [on GitHub][release-notes].
+
+[CI-S]: https://github.com/Zastai/MetaBrainz.CritiqueBrainz/actions/workflows/build.yml/badge.svg
+[CI-L]: https://github.com/Zastai/MetaBrainz.CritiqueBrainz/actions/workflows/build.yml
+
+[NuGet-S]: https://img.shields.io/nuget/v/MetaBrainz.CritiqueBrainz
+[NuGet-L]: https://nuget.org/packages/MetaBrainz.CritiqueBrainz
+
+[api-reference]: https://critiquebrainz.readthedocs.io/api.html
 [home]: https://critiquebrainz.org/
 [mb-home]: https://musicbrainz.org/
-[api-reference]: https://critiquebrainz.readthedocs.io/api.html
+
+[release-notes]: https://github.com/Zastai/MetaBrainz.CritiqueBrainz/releases

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,0 @@
-version: 'Build #{build}'
-image: Visual Studio 2022
-build_script:
-  - ps: .\build-package.ps1 -Configuration Debug
-after_build:
-  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -3,6 +3,7 @@
 [CmdletBinding()]
 param (
   [string] $Configuration = 'Release',
+  [switch] $ContinuousIntegration = $false,
   [switch] $WithBinLog = $false
 )
 
@@ -41,7 +42,15 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Building the solution (Configuration: $Configuration)..."
-dotnet build $opts --no-restore "-c:$Configuration" '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+$props = @()
+if ($ContinuousIntegration) {
+  $props += '-p:ContinuousIntegrationBuild=true'
+  $props += '-p:Deterministic=true'
+}
+if ($Configuration -eq 'Debug') {
+  $props += '-p:DebugMessageImportance=high'
+}
+dotnet build $opts --no-restore "-c:$Configuration" $props
 Complete-BuildStep 'build'
 if ($LASTEXITCODE -ne 0) {
   Write-Error "SOLUTION BUILD FAILED"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-    "MetaBrainz.Build.Sdk" : "2.1.2"
-  }
-}

--- a/public-api/MetaBrainz.CritiqueBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.CritiqueBrainz.net6.0.cs.md
@@ -1,0 +1,117 @@
+﻿# API Reference: MetaBrainz.CritiqueBrainz
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+```
+
+## Namespace: MetaBrainz.CritiqueBrainz
+
+### Type: AuthorizationScope
+
+```cs
+[System.FlagsAttribute]
+public enum AuthorizationScope {
+
+  Everything = -1,
+  None = 0,
+  Review = 1,
+  User = 4,
+  Vote = 2,
+
+}
+```
+
+### Type: OAuth2
+
+```cs
+public class OAuth2 {
+
+  public const string AuthorizationEndPoint = "/oauth/authorize";
+
+  public static readonly System.Uri OutOfBandUri;
+
+  public const string TokenEndPoint = "/ws/1/oauth/token";
+
+  string ClientId {
+    public get;
+    public set;
+  }
+
+  string DefaultClientId {
+    public static get;
+    public static set;
+  }
+
+  int DefaultPort {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUrlScheme {
+    public static get;
+    public static set;
+  }
+
+  string DefaultWebSite {
+    public static get;
+    public static set;
+  }
+
+  int Port {
+    public get;
+    public set;
+  }
+
+  string UrlScheme {
+    public get;
+    public set;
+  }
+
+  string WebSite {
+    public get;
+    public set;
+  }
+
+  public OAuth2();
+
+  public System.Uri CreateAuthorizationRequest(System.Uri redirectUri, AuthorizationScope scope, string? state = null);
+
+  public MetaBrainz.CritiqueBrainz.Interfaces.IAuthorizationToken GetBearerToken(string code, string clientSecret, System.Uri redirectUri);
+
+  public System.Threading.Tasks.Task<MetaBrainz.CritiqueBrainz.Interfaces.IAuthorizationToken> GetBearerTokenAsync(string code, string clientSecret, System.Uri redirectUri);
+
+  public MetaBrainz.CritiqueBrainz.Interfaces.IAuthorizationToken RefreshBearerToken(string refreshToken, string clientSecret);
+
+  public System.Threading.Tasks.Task<MetaBrainz.CritiqueBrainz.Interfaces.IAuthorizationToken> RefreshBearerTokenAsync(string refreshToken, string clientSecret);
+
+}
+```
+
+## Namespace: MetaBrainz.CritiqueBrainz.Interfaces
+
+### Type: IAuthorizationToken
+
+```cs
+public interface IAuthorizationToken : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string? AccessToken {
+    public abstract get;
+  }
+
+  int Lifetime {
+    public abstract get;
+  }
+
+  string? RefreshToken {
+    public abstract get;
+  }
+
+  string? TokenType {
+    public abstract get;
+  }
+
+}
+```

--- a/public-api/MetaBrainz.CritiqueBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.CritiqueBrainz.net8.0.cs.md
@@ -1,0 +1,117 @@
+﻿# API Reference: MetaBrainz.CritiqueBrainz
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+```
+
+## Namespace: MetaBrainz.CritiqueBrainz
+
+### Type: AuthorizationScope
+
+```cs
+[System.FlagsAttribute]
+public enum AuthorizationScope {
+
+  Everything = -1,
+  None = 0,
+  Review = 1,
+  User = 4,
+  Vote = 2,
+
+}
+```
+
+### Type: OAuth2
+
+```cs
+public class OAuth2 {
+
+  public const string AuthorizationEndPoint = "/oauth/authorize";
+
+  public static readonly System.Uri OutOfBandUri;
+
+  public const string TokenEndPoint = "/ws/1/oauth/token";
+
+  string ClientId {
+    public get;
+    public set;
+  }
+
+  string DefaultClientId {
+    public static get;
+    public static set;
+  }
+
+  int DefaultPort {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUrlScheme {
+    public static get;
+    public static set;
+  }
+
+  string DefaultWebSite {
+    public static get;
+    public static set;
+  }
+
+  int Port {
+    public get;
+    public set;
+  }
+
+  string UrlScheme {
+    public get;
+    public set;
+  }
+
+  string WebSite {
+    public get;
+    public set;
+  }
+
+  public OAuth2();
+
+  public System.Uri CreateAuthorizationRequest(System.Uri redirectUri, AuthorizationScope scope, string? state = null);
+
+  public MetaBrainz.CritiqueBrainz.Interfaces.IAuthorizationToken GetBearerToken(string code, string clientSecret, System.Uri redirectUri);
+
+  public System.Threading.Tasks.Task<MetaBrainz.CritiqueBrainz.Interfaces.IAuthorizationToken> GetBearerTokenAsync(string code, string clientSecret, System.Uri redirectUri);
+
+  public MetaBrainz.CritiqueBrainz.Interfaces.IAuthorizationToken RefreshBearerToken(string refreshToken, string clientSecret);
+
+  public System.Threading.Tasks.Task<MetaBrainz.CritiqueBrainz.Interfaces.IAuthorizationToken> RefreshBearerTokenAsync(string refreshToken, string clientSecret);
+
+}
+```
+
+## Namespace: MetaBrainz.CritiqueBrainz.Interfaces
+
+### Type: IAuthorizationToken
+
+```cs
+public interface IAuthorizationToken : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string? AccessToken {
+    public abstract get;
+  }
+
+  int Lifetime {
+    public abstract get;
+  }
+
+  string? RefreshToken {
+    public abstract get;
+  }
+
+  string? TokenType {
+    public abstract get;
+  }
+
+}
+```


### PR DESCRIPTION
- update GitHub Actions
- drop AppVeyor builds
  - instead, use GitHub Actions for CI
- enable Dependabot for GitHub Actions and configure labels for it
- set `AssemblyIsComVisible` to `false` in the project file
- align copyright years between license file and project
- add public API reference
- target `net6.0` and `net8.0` only
  - allows dropping some compatibility code

This also bumps `JetBrains.Annotations` to version 2023.3.0.