### PR TITLE
Update support libraries and add trace source

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="MetaBrainz.Common" Version="3.0.0" />
-    <PackageVersion Include="MetaBrainz.Common.Json" Version="5.1.0" />
+    <PackageVersion Include="MetaBrainz.Common.Json" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
-    <PackageVersion Include="MetaBrainz.Common" Version="1.0.0" />
+    <PackageVersion Include="MetaBrainz.Common" Version="3.0.0" />
     <PackageVersion Include="MetaBrainz.Common.Json" Version="5.1.0" />
   </ItemGroup>
 

--- a/MetaBrainz.CritiqueBrainz/MetaBrainz.CritiqueBrainz.csproj
+++ b/MetaBrainz.CritiqueBrainz/MetaBrainz.CritiqueBrainz.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.1" />
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.2" />
 
   <PropertyGroup>
     <Authors>Zastai</Authors>

--- a/MetaBrainz.CritiqueBrainz/OAuth2.cs
+++ b/MetaBrainz.CritiqueBrainz/OAuth2.cs
@@ -84,6 +84,9 @@ public sealed class OAuth2 : IDisposable {
   /// <summary>The content type for a token request body.</summary>
   public const string TokenRequestBodyType = "application/x-www-form-urlencoded";
 
+  /// <summary>The trace source (named 'MetaBrainz.CritiqueBrainz.OAuth2') used by this class.</summary>
+  public static readonly TraceSource TraceSource = new("MetaBrainz.CritiqueBrainz.OAuth2", SourceLevels.Off);
+
   #endregion
 
   #region Constructors
@@ -332,7 +335,8 @@ public sealed class OAuth2 : IDisposable {
 
   private async Task<HttpResponseMessage> PerformRequestAsync(Uri uri, HttpMethod method, HttpContent? body,
                                                               CancellationToken cancellationToken) {
-    Debug.Print("[{0}] WEB SERVICE REQUEST: {1} {2}", DateTime.UtcNow, method.Method, uri);
+    var ts = OAuth2.TraceSource;
+    ts.TraceEvent(TraceEventType.Verbose, 1, "WEB SERVICE REQUEST: {0} {1}", method.Method, uri);
     var client = this.Client;
     using var request = new HttpRequestMessage(method, uri);
     request.Content = body;
@@ -343,17 +347,25 @@ public sealed class OAuth2 : IDisposable {
     }
     request.Headers.UserAgent.Add(OAuth2.LibraryProductInfo);
     request.Headers.UserAgent.Add(OAuth2.LibraryComment);
-    Debug.Print("[{0}] => HEADERS: {1}", DateTime.UtcNow, TextUtils.FormatMultiLine(request.Headers.ToString()));
-    if (body is not null) {
-      // FIXME: Should this include the actual body text too?
-      Debug.Print("[{0}] => BODY ({1}): {2} bytes", DateTime.UtcNow, body.Headers.ContentType, body.Headers.ContentLength ?? 0);
+    if (ts.Switch.ShouldTrace(TraceEventType.Verbose)) {
+      ts.TraceEvent(TraceEventType.Verbose, 2, "HEADERS: {0}", TextUtils.FormatMultiLine(request.Headers.ToString()));
+      if (body is not null) {
+        var headers = body.Headers;
+        ts.TraceEvent(TraceEventType.Verbose, 3, "BODY ({0}): {1} bytes", headers.ContentType, headers.ContentLength ?? 0);
+        // FIXME: Should we trace the actual body text too?
+      }
+      else {
+        ts.TraceEvent(TraceEventType.Verbose, 3, "NO BODY");
+      }
     }
     var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-    Debug.Print("[{0}] WEB SERVICE RESPONSE: {1}/{2} '{3}' (v{4})", DateTime.UtcNow, (int) response.StatusCode, response.StatusCode,
-                response.ReasonPhrase, response.Version);
-    Debug.Print("[{0}] => HEADERS: {1}", DateTime.UtcNow, TextUtils.FormatMultiLine(response.Headers.ToString()));
-    Debug.Print("[{0}] => CONTENT ({1}): {2} bytes", DateTime.UtcNow, response.Content.Headers.ContentType,
-                response.Content.Headers.ContentLength ?? 0);
+    if (ts.Switch.ShouldTrace(TraceEventType.Verbose)) {
+      ts.TraceEvent(TraceEventType.Verbose, 4, "WEB SERVICE RESPONSE: {0:D}/{0} '{1}' (v{2})", response.StatusCode,
+                    response.ReasonPhrase, response.Version);
+      ts.TraceEvent(TraceEventType.Verbose, 5, "HEADERS: {0}", TextUtils.FormatMultiLine(response.Headers.ToString()));
+      var headers = response.Content.Headers;
+      ts.TraceEvent(TraceEventType.Verbose, 6, "CONTENT ({0}): {1} bytes", headers.ContentType, headers.ContentLength ?? 0);
+    }
     return await response.EnsureSuccessfulAsync(cancellationToken);
   }
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ music encyclopedia.
 
 This also contains OAuth2 functionality.
 
-## Release Notes
-
-These are available [on GitHub][release-notes].
-
 [CI-S]: https://github.com/Zastai/MetaBrainz.CritiqueBrainz/actions/workflows/build.yml/badge.svg
 [CI-L]: https://github.com/Zastai/MetaBrainz.CritiqueBrainz/actions/workflows/build.yml
 
@@ -22,5 +18,76 @@ These are available [on GitHub][release-notes].
 [api-reference]: https://critiquebrainz.readthedocs.io/api.html
 [home]: https://critiquebrainz.org/
 [mb-home]: https://musicbrainz.org/
+
+## Debugging
+
+The `OAuth2` class provides a `TraceSource` that can be used to
+configure debug output; its name is `MetaBrainz.CritiqueBrainz.OAuth2`.
+
+### Configuration
+
+#### In Code
+
+In code, you can enable tracing like follows:
+
+```cs
+// Use the default switch, turning it on.
+OAuth2.TraceSource.Switch.Level = SourceLevels.All;
+
+// Alternatively, use your own switch so multiple things can be
+// enabled/disabled at the same time.
+var mySwitch = new TraceSwitch("MyAppDebugSwitch", "All");
+OAuth2.TraceSource.Switch = mySwitch;
+
+// By default, there is a single listener that writes trace events to
+// the debug output (typically only seen in an IDE's debugger). You can
+// add (and remove) listeners as desired.
+var listener = new ConsoleTraceListener {
+  Name = "MyAppConsole",
+  TraceOutputOptions = TraceOptions.DateTime | TraceOptions.ProcessId,
+};
+OAuth2.TraceSource.Listeners.Clear();
+OAuth2.TraceSource.Listeners.Add(listener);
+```
+
+#### In Configuration
+
+Starting from .NET 7 your application can also be set up to read tracing
+configuration from the application configuration file. To do so, the
+application needs to add the following to its startup code:
+
+```cs
+System.Diagnostics.TraceConfiguration.Register();
+```
+
+(Provided by the `System.Configuration.ConfigurationManager` package.)
+
+The application config file can then have a `system.diagnostics` section
+where sources, switches and listeners can be configured.
+
+```xml
+<configuration>
+  <system.diagnostics>
+    <sharedListeners>
+      <add name="console" type="System.Diagnostics.ConsoleTraceListener" traceOutputOptions="DateTime,ProcessId" />
+    </sharedListeners>
+    <sources>
+      <source name="MetaBrainz.CritiqueBrainz.OAuth2" switchName="MetaBrainz.CritiqueBrainz">
+        <listeners>
+          <add name="console" />
+          <add name="cb-oauth2-log" type="System.Diagnostics.TextWriterTraceListener" initializeData="cb.oauth2.log" />
+        </listeners>
+      </source>
+    </sources>
+    <switches>
+      <add name="MetaBrainz.CritiqueBrainz" value="All" />
+    </switches>
+  </system.diagnostics>
+</configuration>
+```
+
+## Release Notes
+
+These are available [on GitHub][release-notes].
 
 [release-notes]: https://github.com/Zastai/MetaBrainz.CritiqueBrainz/releases

--- a/public-api/MetaBrainz.CritiqueBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.CritiqueBrainz.net6.0.cs.md
@@ -37,6 +37,8 @@ public sealed class OAuth2 : System.IDisposable {
 
   public const string TokenRequestBodyType = "application/x-www-form-urlencoded";
 
+  public static readonly System.Diagnostics.TraceSource TraceSource;
+
   string ClientId {
     public get;
     public set;

--- a/public-api/MetaBrainz.CritiqueBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.CritiqueBrainz.net8.0.cs.md
@@ -37,6 +37,8 @@ public sealed class OAuth2 : System.IDisposable {
 
   public const string TokenRequestBodyType = "application/x-www-form-urlencoded";
 
+  public static readonly System.Diagnostics.TraceSource TraceSource;
+
   string ClientId {
     public get;
     public set;


### PR DESCRIPTION
This updates `MetaBrainz.Build.Sdk` to v3.1.2, `MetaBrainz.Common` to v3.0.0 and `MetaBrainz.Common.Json` to v6.0.1.

It also switches the debug output for `OAuth2` over to a trace source, to make it available in a release build too (and, by extension, in the NuGet package). Information on how to enable it has been added to the README.
